### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -53,14 +53,14 @@
         "timeout": 30,
         "settingsInjection": {
           "client_id": {
-            "headers": ["Authorization"]
+            "header": ["Authorization"]
           },
           "client_secret": {
-            "headers": ["Authorization"]
+            "header": ["Authorization"]
           },
           "global_access_token": {
             "body": ["refresh_token"],
-            "headers": ["xero-tenant-id"]
+            "header": ["xero-tenant-id"]
           }
         }
       }

--- a/manifest.json
+++ b/manifest.json
@@ -50,7 +50,19 @@
       {
         "url": "https://(.*).xero.com/.*",
         "methods": ["GET", "POST", "PUT", "DELETE", "PATCH"],
-        "timeout": 30
+        "timeout": 30,
+        "settingsInjection": {
+          "client_id": {
+            "headers": ["Authorization"]
+          },
+          "client_secret": {
+            "headers": ["Authorization"]
+          },
+          "global_access_token": {
+            "body": ["refresh_token"],
+            "headers": ["xero-tenant-id"]
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
This pull request introduces a new `settingsInjection` configuration to the `manifest.json` file, enhancing how sensitive credentials and tokens are mapped to HTTP request headers and body fields. This change improves the flexibility and security of API integrations by explicitly defining how settings are injected into requests.

Settings injection for API requests:

* Added a `settingsInjection` object to the API configuration, specifying how `client_id` and `client_secret` are injected into the `Authorization` header, and how `global_access_token` is injected into both the request body (`refresh_token`) and the `xero-tenant-id` header.